### PR TITLE
add options augument to initializer

### DIFF
--- a/lib/shrine/plugins/hanami.rb
+++ b/lib/shrine/plugins/hanami.rb
@@ -6,7 +6,7 @@ class Shrine
   module Plugins
     module Hanami
       module AttachmentMethods
-        def initialize(name)
+        def initialize(name, **options)
           super
 
           module_eval <<-RUBY, __FILE__, __LINE__ + 1


### PR DESCRIPTION
Hi, when I use hanami-shrine i got following AugumentError.

```
/home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-shrine-0.3.0/lib/shrine/plugins/hanami.rb:9:in `initialize': wrong number of arguments (given 2, expected 1) (ArgumentError)
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/shrine-2.7.0/lib/shrine.rb:158:in `new'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/shrine-2.7.0/lib/shrine.rb:158:in `attachment'
	from /home/fumio/workspace/someapp/lib/someapp/entities/contract_version.rb:4:in `<class:ContractVersion>'
	from /home/fumio/workspace/someapp/lib/someapp/entities/contract_version.rb:3:in `<top (required)>'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-utils-1.0.4/lib/hanami/utils.rb:68:in `load'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-utils-1.0.4/lib/hanami/utils.rb:68:in `block in reload!'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-utils-1.0.4/lib/hanami/utils.rb:90:in `each'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-utils-1.0.4/lib/hanami/utils.rb:90:in `for_each_file_in'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-utils-1.0.4/lib/hanami/utils.rb:68:in `reload!'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/components/components.rb:59:in `block (2 levels) in <module:Components>'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/components/component.rb:40:in `call'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/components.rb:85:in `block (2 levels) in resolve'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/concurrent-ruby-1.0.5/lib/concurrent/map.rb:133:in `block in fetch_or_store'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/concurrent-ruby-1.0.5/lib/concurrent/map.rb:122:in `fetch'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/concurrent-ruby-1.0.5/lib/concurrent/map.rb:132:in `fetch_or_store'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/components.rb:83:in `block in resolve'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/components.rb:82:in `each'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/components.rb:82:in `resolve'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/components/component.rb:138:in `resolve_requirements'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/components/component.rb:36:in `call'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/components.rb:85:in `block (2 levels) in resolve'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/concurrent-ruby-1.0.5/lib/concurrent/map.rb:133:in `block in fetch_or_store'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/concurrent-ruby-1.0.5/lib/concurrent/map.rb:122:in `fetch'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/concurrent-ruby-1.0.5/lib/concurrent/map.rb:132:in `fetch_or_store'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/components.rb:83:in `block in resolve'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/components.rb:82:in `each'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/components.rb:82:in `resolve'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/commands/command.rb:57:in `initialize'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/commands/console.rb:52:in `initialize'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/cli.rb:89:in `new'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/lib/hanami/cli.rb:89:in `console'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/gems/hanami-1.0.0/bin/hanami:5:in `<top (required)>'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/bin/hanami:23:in `load'
	from /home/fumio/workspace/someapp/vendor/bundle/ruby/2.3.0/bin/hanami:23:in `<main>'
```

Since shrine updated 2.7.0, it passes attachment two augments. I don't know what new `**options` exactly means, but with appending `**option` augment in initializer solves this error.