### PR TITLE
Convert JSON(B) column value to hash after reading from repository 

### DIFF
--- a/lib/shrine/plugins/hanami.rb
+++ b/lib/shrine/plugins/hanami.rb
@@ -123,6 +123,18 @@ class Shrine
           end
         end
       end
+
+      module AttacherMethods
+        private
+
+        def convert_after_read(value)
+          sequel_json_value?(value) ? value.to_hash : super
+        end
+
+        def sequel_json_value?(value)
+          defined?(Sequel::Postgres::JSONHashBase) && value.is_a?(Sequel::Postgres::JSONHashBase)
+        end
+      end
     end
 
     register_plugin(:hanami, Hanami)

--- a/lib/shrine/plugins/hanami.rb
+++ b/lib/shrine/plugins/hanami.rb
@@ -11,7 +11,6 @@ class Shrine
 
           module_eval <<-RUBY, __FILE__, __LINE__ + 1
             module EntitySupport
-              attr_reader :attributes
               def initialize(attributes)
                 attachment = attributes[:#{name}]
                 @_#{name} = attachment


### PR DESCRIPTION
This PR enables users to use Postgres' JSON(B) column to store attachment data, similar to how it is done in the [sequel](https://github.com/janko-m/shrine/blob/0a0d415dd006d7a948770d0ae824f9799f4eecfc/lib/shrine/plugins/sequel.rb#L119-L132) and [activerecord](https://github.com/janko-m/shrine/blob/0a0d415dd006d7a948770d0ae824f9799f4eecfc/lib/shrine/plugins/activerecord.rb#L139-L151) plugins. I didn't add tests because it would require either completely switching to Postgres as the database for running tests or setting up Postgres separately for Postgres-related tests.